### PR TITLE
fix: Correct S3 base path extraction for variant stream uploads

### DIFF
--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -244,11 +244,20 @@ export async function uploadResult(
 ) {
   // For HLS workflows with segments, sync entire staging directory to S3
   if (s3SegmentPattern && dest.protocol === 's3:') {
-    // Extract the base S3 path from the segment pattern or dest
-    const s3BasePath = s3SegmentPattern.substring(
-      0,
-      s3SegmentPattern.lastIndexOf('/') + 1
-    );
+    // Extract the base S3 path, removing variant stream directories and filenames
+    let s3BasePath = s3SegmentPattern;
+
+    // Remove the filename part (segment_%03d.ts)
+    s3BasePath = s3BasePath.substring(0, s3BasePath.lastIndexOf('/') + 1);
+
+    // If this is a variant stream path (contains %v), remove that directory level too
+    if (s3BasePath.includes('%v')) {
+      s3BasePath = s3BasePath.substring(
+        0,
+        s3BasePath.lastIndexOf('/', s3BasePath.length - 2) + 1
+      );
+    }
+
     const s3BaseUrl = toUrl(s3BasePath);
 
     console.log(`Syncing HLS output to ${s3BaseUrl.toString()}`);


### PR DESCRIPTION
## Summary
• Fixes incorrect S3 upload path calculation for HLS variant streams
• Removes %v placeholder when determining sync destination directory
• Ensures proper base path extraction for variant stream workflows
• Resolves upload path issues where files were synced to wrong S3 locations

## Problem Fixed
The upload was incorrectly syncing to paths with literal `%v` placeholders:
```
❌ Syncing HLS output to s3://output/project/stream_%v/
✅ Should sync to:      s3://output/project/
```

This happened because the S3 base path extraction was including the variant stream directory (`stream_%v/`) in the sync destination, but FFmpeg actually creates directories like `stream_0/`, `stream_1/`, etc.

## Root Cause
When FFmpeg processes variant streams:
1. **Input pattern**: `s3://output/project/stream_%v/segment_%03d.ts`
2. **FFmpeg creates**: `stream_0/segment_000.ts`, `stream_1/segment_001.ts`, etc.
3. **Old logic synced to**: `s3://output/project/stream_%v/` (literal %v)
4. **New logic syncs to**: `s3://output/project/` (correct base)

## Solution
Enhanced the S3 base path extraction:
1. **Remove filename** (`segment_%03d.ts` → `stream_%v/`)
2. **Detect %v placeholder** in remaining path
3. **Remove variant directory** (`stream_%v/` → base path)
4. **Sync to correct base** (`s3://output/project/`)

## Example Fix
```bash
# Segment pattern
s3://output/1762761020001-project/stream_%v/segment_%03d.ts

# Before (wrong)
→ sync to: s3://output/1762761020001-project/stream_%v/

# After (correct) 
→ sync to: s3://output/1762761020001-project/
```

## Test Plan
- [x] Path extraction logic handles both variant and non-variant streams
- [x] %v placeholder properly removed from sync destination
- [x] Base path correctly calculated for nested directory structures
- [x] Sync preserves actual FFmpeg-generated directory structure

This fixes the upload path issue for HLS variant streams while maintaining compatibility with regular HLS workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)